### PR TITLE
Fix missing roles from Wishlist.

### DIFF
--- a/vanilla-forums.wishlist.php
+++ b/vanilla-forums.wishlist.php
@@ -42,7 +42,7 @@ if (!function_exists('vf_get_user_wishlist')) {
          if (isset($user['roles']))
             $roles = explode(',', $user['roles']);
 
-         $roles = array_merge($roles, array_values($wishlistRoles));
+         $roles = array_merge($roles, $wishlistRoles);
          $roles = array_unique($roles);
          $user['roles'] = implode(',', $roles);      
       }

--- a/vanilla-forums.wishlist.php
+++ b/vanilla-forums.wishlist.php
@@ -31,13 +31,18 @@ if (!function_exists('vf_get_user_wishlist')) {
    function vf_get_user_wishlist($user) {
       $levels = WLMAPI::wlmapi_get_member_levels($current_user->ID);
 
-      $levels = get_object_vars($levels[0]);
+      $wishlistRoles = [];
+      foreach ($levels as $level) {
+          if ($level->Active && !$level->Cancelled && !$level->Expired) {
+              $wishlistRoles[] = $level->Name;  
+          }
+      }
       if (is_array($levels)) {
          $roles = array();
          if (isset($user['roles']))
             $roles = explode(',', $user['roles']);
 
-         $roles = array_merge($roles, array_values($levels));
+         $roles = array_merge($roles, array_values($wishlistRoles));
          $roles = array_unique($roles);
          $user['roles'] = implode(',', $roles);      
       }

--- a/vanilla-forums.wishlist.php
+++ b/vanilla-forums.wishlist.php
@@ -31,6 +31,7 @@ if (!function_exists('vf_get_user_wishlist')) {
    function vf_get_user_wishlist($user) {
       $levels = WLMAPI::wlmapi_get_member_levels($current_user->ID);
 
+      $levels = get_object_vars($levels[0]);
       if (is_array($levels)) {
          $roles = array();
          if (isset($user['roles']))


### PR DESCRIPTION
Get the array of levels from the object levels in the Wordpress Wishlist plugin.

According to Wordpress Wishlist documentation the Levels come as an Object wrapped in an Array.

See https://codex.wishlistproducts.com/function-reference-wlmapi_get_member_levels/